### PR TITLE
Read assembly version

### DIFF
--- a/Tvl.NuGet.BuildTasks/FindPackageInputs.cs
+++ b/Tvl.NuGet.BuildTasks/FindPackageInputs.cs
@@ -1,7 +1,9 @@
 ﻿namespace Tvl.NuGet.BuildTasks
 {
+    using System.Collections.Generic;
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
+    using Path = System.IO.Path;
 
     public class FindPackageInputs : Task
     {
@@ -47,6 +49,13 @@
             set;
         }
 
+        [Required]
+        public bool Symbols
+        {
+            get;
+            set;
+        }
+
         [Output]
         public ITaskItem[] PackageInputs
         {
@@ -54,9 +63,31 @@
             set;
         }
 
+        [Output]
+        public ITaskItem[] PackageOutputs
+        {
+            get;
+            set;
+        }
+
         public override bool Execute()
         {
+            // Identify the package inputs
             PackageInputs = new ITaskItem[0];
+
+            // Identify the package outputs
+            List<ITaskItem> outputs = new List<ITaskItem>();
+            foreach (var manifest in Manifests)
+            {
+                // TODO: use the actual <id> value instead of the file name.
+                string packageId = Path.GetFileNameWithoutExtension(manifest.ItemSpec);
+                outputs.Add(new TaskItem(Path.Combine(OutputDirectory, $"{packageId}.{Version}.nupkg")));
+                if (Symbols)
+                    outputs.Add(new TaskItem(Path.Combine(OutputDirectory, $"{packageId}.{Version}.symbols.nupkg")));
+            }
+
+            PackageOutputs = outputs.ToArray();
+
             return true;
         }
     }

--- a/Tvl.NuGet.BuildTasks/SetNuGetManifestMetadata.cs
+++ b/Tvl.NuGet.BuildTasks/SetNuGetManifestMetadata.cs
@@ -1,0 +1,108 @@
+﻿namespace Tvl.NuGet.BuildTasks
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection.Metadata;
+    using System.Reflection.PortableExecutable;
+    using Microsoft.Build.Framework;
+    using Microsoft.Build.Utilities;
+    using AssemblyFileVersionAttribute = System.Reflection.AssemblyFileVersionAttribute;
+    using AssemblyInformationalVersionAttribute = System.Reflection.AssemblyInformationalVersionAttribute;
+    using File = System.IO.File;
+
+    public class SetNuGetManifestMetadata : Task
+    {
+        [Required]
+        public ITaskItem AssemblyFile
+        {
+            get;
+            set;
+        }
+
+        [Required]
+        public ITaskItem[] Manifests
+        {
+            get;
+            set;
+        }
+
+        [Output]
+        public ITaskItem[] OutputItems
+        {
+            get;
+            set;
+        }
+
+        public override bool Execute()
+        {
+            OutputItems = new ITaskItem[0];
+
+            if (Manifests.All(i => !string.IsNullOrEmpty(i.GetMetadata("Version"))))
+                return true;
+
+            if (!File.Exists(AssemblyFile.ItemSpec))
+                return false;
+
+            using (PEReader targetExecutable = new PEReader(File.OpenRead(AssemblyFile.ItemSpec), PEStreamOptions.PrefetchMetadata))
+            {
+                string informationalVersion = null;
+                string fileVersion = null;
+
+                MetadataReader reader = targetExecutable.GetMetadataReader();
+                foreach (CustomAttributeHandle customAttributeHandle in reader.GetAssemblyDefinition().GetCustomAttributes())
+                {
+                    CustomAttribute customAttribute = reader.GetCustomAttribute(customAttributeHandle);
+                    if (customAttribute.Constructor.Kind != HandleKind.MemberReference)
+                        continue;
+
+                    MemberReference constructorMemberReference = reader.GetMemberReference((MemberReferenceHandle)customAttribute.Constructor);
+                    if (constructorMemberReference.Parent.Kind != HandleKind.TypeReference)
+                        continue;
+
+                    TypeReference attributeTypeReference = reader.GetTypeReference((TypeReferenceHandle)constructorMemberReference.Parent);
+                    if (reader.StringComparer.Equals(attributeTypeReference.Name, nameof(AssemblyInformationalVersionAttribute))
+                        && reader.StringComparer.Equals(attributeTypeReference.Namespace, typeof(AssemblyInformationalVersionAttribute).Namespace))
+                    {
+                        BlobReader blobReader = reader.GetBlobReader(customAttribute.Value);
+                        var prolog = blobReader.ReadUInt16();
+                        // the version is the first and only fixed arg
+                        informationalVersion = blobReader.ReadSerializedString();
+
+                        if (!string.IsNullOrEmpty(informationalVersion))
+                            break;
+                    }
+                    else if (reader.StringComparer.Equals(attributeTypeReference.Name, nameof(AssemblyFileVersionAttribute))
+                        && reader.StringComparer.Equals(attributeTypeReference.Namespace, typeof(AssemblyFileVersionAttribute).Namespace))
+                    {
+                        BlobReader blobReader = reader.GetBlobReader(customAttribute.Value);
+                        var prolog = blobReader.ReadUInt16();
+                        // the version is the first and only fixed arg
+                        fileVersion = blobReader.ReadSerializedString();
+                    }
+                }
+
+                string version;
+                if (!string.IsNullOrEmpty(informationalVersion))
+                    version = informationalVersion;
+                else if (!string.IsNullOrEmpty(fileVersion))
+                    version = fileVersion;
+                else
+                    version = reader.GetAssemblyDefinition().Version.ToString();
+
+                List<ITaskItem> updatedItems = new List<ITaskItem>();
+                foreach (var manifest in Manifests)
+                {
+                    if (!string.IsNullOrEmpty(manifest.GetMetadata("Version")))
+                        continue;
+
+                    manifest.SetMetadata("Version", version);
+                    updatedItems.Add(manifest);
+                }
+
+                OutputItems = updatedItems.ToArray();
+            }
+
+            return true;
+        }
+    }
+}

--- a/Tvl.NuGet.BuildTasks/Tvl.NuGet.BuildTasks.csproj
+++ b/Tvl.NuGet.BuildTasks/Tvl.NuGet.BuildTasks.csproj
@@ -34,7 +34,15 @@
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Reflection.Metadata, Version=1.0.19.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.0.19-rc\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -45,6 +53,7 @@
     <Compile Include="CreatePackage.cs" />
     <Compile Include="FindPackageInputs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SetNuGetManifestMetadata.cs" />
   </ItemGroup>
   <ItemGroup>
     <NuGetManifest Include="Tvl.NuGet.BuildTasks.nuspec">

--- a/Tvl.NuGet.BuildTasks/Tvl.NuGet.BuildTasks.nuspec
+++ b/Tvl.NuGet.BuildTasks/Tvl.NuGet.BuildTasks.nuspec
@@ -26,6 +26,8 @@
     <file src="Tvl.NuGet.BuildTasks.props" target="build\Tvl.NuGet.BuildTasks.props"/>
     <file src="Tvl.NuGet.BuildTasks.targets" target="build\Tvl.NuGet.BuildTasks.targets"/>
     <file src="$OutDir$Tvl.NuGet.BuildTasks.dll" target="build"/>
+    <file src="$OutDir$System.Collections.Immutable.dll" target="build"/>
+    <file src="$OutDir$System.Reflection.Metadata.dll" target="build"/>
   </files>
 
 </package>

--- a/Tvl.NuGet.BuildTasks/Tvl.NuGet.BuildTasks.targets
+++ b/Tvl.NuGet.BuildTasks/Tvl.NuGet.BuildTasks.targets
@@ -98,9 +98,11 @@
       Manifests="@(NuGetManifest)"
       OutputDirectory="%(NuGetManifest.OutputDirectory)"
       BasePath="%(NuGetManifest.BasePath)"
-      Version="%(NuGetManifest.Version)">
+      Version="%(NuGetManifest.Version)"
+      Symbols="%(NuGetManifest.Symbols)">
 
       <Output ItemName="CreateNuGetPackageInputs" TaskParameter="PackageInputs" />
+      <Output ItemName="NuGetCurrentOutputPackageFilesList" TaskParameter="PackageOutputs" />
     </FindPackageInputs>
 
     <!-- This is a hack to make sure the output assembly gets included prior to properly implementing FindPackageInputs -->
@@ -118,6 +120,7 @@
           Condition="'@(NuGetManifest)' != ''"
           Inputs="@(NuGetManifest);@(CreateNuGetPackageInputs)"
           Outputs="@(NuGetOutputPackageFilesList);
+                  @(NuGetCurrentOutputPackageFilesList);
                   $(IntermediateOutputPath)$(NuGetGeneratedPackageFileNames);">
 
     <ItemGroup>

--- a/Tvl.NuGet.BuildTasks/Tvl.NuGet.BuildTasks.targets
+++ b/Tvl.NuGet.BuildTasks/Tvl.NuGet.BuildTasks.targets
@@ -2,6 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="Tvl.NuGet.BuildTasks.CreatePackage" AssemblyFile="$(NuGetBuildTaskPath)\Tvl.NuGet.BuildTasks.dll" />
   <UsingTask TaskName="Tvl.NuGet.BuildTasks.FindPackageInputs" AssemblyFile="$(NuGetBuildTaskPath)\Tvl.NuGet.BuildTasks.dll" />
+  <UsingTask TaskName="Tvl.NuGet.BuildTasks.SetNuGetManifestMetadata" AssemblyFile="$(NuGetBuildTaskPath)\Tvl.NuGet.BuildTasks.dll" />
 
   <PropertyGroup>
     <NuGetGeneratedPackageFileNames Condition="'$(NuGetGeneratedPackageFileNames)' == ''">$(MSBuildProjectFile).NuGetGeneratedPackagesListAbsolute.txt</NuGetGeneratedPackageFileNames>
@@ -24,7 +25,8 @@
 
     <FindNuGetPackageInputsDependsOn>
       $(FindNuGetPackageInputsDependsOn);
-      CopyFilesToOutputDirectory
+      CopyFilesToOutputDirectory;
+      EnsureNuGetManifestMetadata;
     </FindNuGetPackageInputsDependsOn>
   </PropertyGroup>
 
@@ -65,6 +67,25 @@
     <ReadLinesFromFile File="$(IntermediateOutputPath)$(NuGetGeneratedPackageFileNames)">
       <Output TaskParameter="Lines" ItemName="NuGetOutputPackageFilesList"/>
     </ReadLinesFromFile>
+  </Target>
+
+  <Target Name="EnsureNuGetManifestMetadata"
+          DependsOnTargets="CopyFilesToOutputDirectory"
+          Condition="'@(NuGetManifest)' != ''">
+
+    <SetNuGetManifestMetadata
+      AssemblyFile="@(IntermediateAssembly)"
+      Manifests="@(NuGetManifest)">
+
+      <Output ItemName="_Temp" TaskParameter="OutputItems" />
+    </SetNuGetManifestMetadata>
+
+    <ItemGroup>
+      <NuGetManifest Remove="@(_Temp)" />
+      <NuGetManifest Include="@(_Temp)" />
+      <_Temp Remove="@(_Temp)" />
+    </ItemGroup>
+
   </Target>
 
   <Target Name="FindNuGetPackageInputs"

--- a/Tvl.NuGet.BuildTasks/packages.config
+++ b/Tvl.NuGet.BuildTasks/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NuGet.CommandLine" version="2.8.3" targetFramework="net45" userInstalled="true" />
+  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" userInstalled="true" />
+  <package id="System.Reflection.Metadata" version="1.0.19-rc" targetFramework="net45" userInstalled="true" />
   <package id="Tvl.NuGet.BuildTasks" version="1.0.0-alpha001" targetFramework="net45" userInstalled="true" />
 </packages>


### PR DESCRIPTION
If the `<Version>` metadata is not specified for a NuGet manifest, the default version is set to the first of the following items which is located:
- The `AssemblyInformationalVersion`
- The `AssemblyFileVersion`
- The `AssemblyVersion`
